### PR TITLE
Add recaptcha to registration form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,11 @@ gem 'decidim', DECIDIM_VERSION
 gem 'decidim-term_customizer', git: 'https://github.com/CodiTramuntana/decidim-module-term_customizer'
 gem 'decidim-conferences', DECIDIM_VERSION
 
+gem 'recaptcha', require: 'recaptcha/rails'
+
+# use deface to decorate Decidim views unobtrusively
+gem 'deface'
+
 group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,11 @@ GEM
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
+    deface (1.5.3)
+      nokogiri (>= 1.6)
+      polyglot
+      rails (>= 4.1)
+      rainbow (>= 2.1.0)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
     delayed_job_active_record (4.1.4)
@@ -459,6 +464,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-tmpl-rails (1.1.0)
       rails (>= 3.1.0)
+    json (2.3.0)
     jwt (2.2.1)
     kaminari (1.2.0)
       activesupport (>= 4.1.0)
@@ -558,6 +564,7 @@ GEM
     pg_search (2.3.2)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    polyglot (0.3.5)
     premailer (1.11.1)
       addressable
       css_parser (>= 1.6.0)
@@ -616,6 +623,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    recaptcha (5.5.0)
+      json
     rectify (0.13.0)
       activemodel (>= 4.1.0)
       activerecord (>= 4.1.0)
@@ -790,6 +799,7 @@ DEPENDENCIES
   decidim-conferences!
   decidim-dev!
   decidim-term_customizer!
+  deface
   delayed_job_active_record
   faker (~> 1.8.4)
   figaro (>= 1.1.1)
@@ -798,6 +808,7 @@ DEPENDENCIES
   listen (~> 3.1.0)
   openssl
   puma (>= 3.0)
+  recaptcha
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ This is a Decidim I2CAT app.
 
 Check the `Rails.application.config.to_prepare` block in `config/initializers/decidim.rb` initializer.
 
+### Recaptcha
+
+To provide recaptcha capabilities the `recaptcha` gem is used.
+The implementation tweaks:
+
+- *render the recaptcha widget*: app/overrides/decidim/devise/registrations/new/recaptcha.html.erb.deface
+- *check if recaptcha is valid in the controller*: app/decorators/decidim/devise/registrations_controller_decorator.rb
+- The recaptcha js tag that should appear in all views has been set via admin panel Configuration / Appearance
+
 ### Proposals
 
 There are some overrides that must be checked on every upgrade:

--- a/app/decorators/decidim/devise/registrations_controller_decorator.rb
+++ b/app/decorators/decidim/devise/registrations_controller_decorator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Decidim::Devise::RegistrationsController.class_eval do
+  prepend_before_action :check_captcha, only: [:create]
+
+  def check_captcha
+    unless verify_recaptcha
+      @form = form(::Decidim::RegistrationForm).from_params(params[:user])
+      unless @form.valid?
+        flash.now[:alert] = @form.errors[:base].join(", ") if @form.errors[:base].any?
+        respond_with_navigational(@form) { render :new }
+      end
+    end
+  end
+
+end

--- a/app/overrides/decidim/devise/registrations/new/recaptcha.html.erb.deface
+++ b/app/overrides/decidim/devise/registrations/new/recaptcha.html.erb.deface
@@ -1,0 +1,11 @@
+<!-- insert_after '#card__newsletter' -->
+<div class="card">
+  <div class="card__content" style="text-align: center">
+    <div style="display: inline-block;">
+      <div><%= flash[:recaptcha_error] %></div>
+      <div class="field">
+        <%= recaptcha_tags %>
+      </div>
+    </fieldset>
+  </div>
+</div>

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -44,7 +44,7 @@ Rails.application.config.to_prepare do
   end
 
   # make decorators available
-  # Dir.glob(Rails.application.root + 'app/decorators/**/*_decorator.rb').each do |c|
-  #   require_dependency(c)
-  # end
+  Dir.glob(Rails.application.root + 'app/decorators/**/*_decorator.rb').each do |c|
+    require_dependency(c)
+  end
 end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,6 @@
+Recaptcha.configure do |config|
+  config.site_key  = ENV["RECAPTCHA_SITE_KEY"]
+  config.secret_key = ENV["RECAPTCHA_SECRET_KEY"]
+  # Uncomment the following line if you are using a proxy server:
+  # config.proxy = 'http://myproxy.com.au:8080'
+end


### PR DESCRIPTION
To provide recaptcha capabilities the `recaptcha` gem is used.
The implementation tweaks:

- *render the recaptcha widget*: app/overrides/decidim/devise/registrations/new/recaptcha.html.erb.deface
- *check if recaptcha is valid in the controller*: app/decorators/decidim/devise/registrations_controller_decorator.rb
- The recaptcha js tag that should appear in all views has been set via admin panel Configuration / Appearance