### PR TITLE
Add followers list and notifications when a user follows an Assembly

### DIFF
--- a/app/cells/decidim/follow_button/show.erb
+++ b/app/cells/decidim/follow_button/show.erb
@@ -1,14 +1,14 @@
 <div id="<%= dom_id(model, :follow) %>">
   <% if current_user %>
     <% if current_user.follows?(model) %>
-      <%= button_to decidim.follow_path(slug: params[:slug]), class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, method: :delete, remote: true do %>
+      <%= button_to decidim.follow_path(slug: (params[:slug] || params[:assembly_slug])), class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, method: :delete, remote: true do %>
         <%= icon "bell", icon_options %>
         <span>
           <%= t("follows.destroy.button", scope: "decidim") %>
         </span>
       <% end %>
     <% else %>
-      <%= button_to decidim.follow_path(slug: params[:slug]), class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, remote: true do %>
+      <%= button_to decidim.follow_path(slug: (params[:slug] || params[:assembly_slug])), class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, remote: true do %>
         <%= icon "bell", icon_options %>
         <span>
           <%= t("follows.create.button", scope: "decidim") %>

--- a/app/cells/decidim/follow_button/show.erb
+++ b/app/cells/decidim/follow_button/show.erb
@@ -1,0 +1,33 @@
+<div id="<%= dom_id(model, :follow) %>">
+  <% if current_user %>
+    <% if current_user.follows?(model) %>
+      <%= button_to decidim.follow_path, class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, method: :delete, remote: true do %>
+        <%= icon "bell", icon_options %>
+        <span>
+          <%= t("follows.destroy.button", scope: "decidim") %>
+        </span>
+      <% end %>
+    <% else %>
+      <%= button_to decidim.follow_path(slug: params[:slug]), class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, remote: true do %>
+        <%= icon "bell", icon_options %>
+        <span>
+          <%= t("follows.create.button", scope: "decidim") %>
+        </span>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= button_to(
+      decidim.follow_path,
+      class: button_classes,
+      params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } },
+      data: { tooltip: true, disable_hover: false },
+      :'aria-haspopup' => true,
+      title: t("decidim.shared.follow_button.sign_in_before_follow"),
+      remote: true) do %>
+      <%= icon "bell", icon_options %>
+      <span>
+        <%= t("follows.create.button", scope: "decidim") %>
+      </span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/cells/decidim/follow_button/show.erb
+++ b/app/cells/decidim/follow_button/show.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id(model, :follow) %>">
   <% if current_user %>
     <% if current_user.follows?(model) %>
-      <%= button_to decidim.follow_path, class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, method: :delete, remote: true do %>
+      <%= button_to decidim.follow_path(slug: params[:slug]), class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, method: :delete, remote: true do %>
         <%= icon "bell", icon_options %>
         <span>
           <%= t("follows.destroy.button", scope: "decidim") %>

--- a/app/controllers/decidim/assemblies/admin/assembly_followers_controller.rb
+++ b/app/controllers/decidim/assemblies/admin/assembly_followers_controller.rb
@@ -15,12 +15,6 @@ module Decidim
             organization: current_organization
           ).followers
         end
-
-        private
-
-        def permitted_params
-          params.permit(:assembly_slug)
-        end
       end
     end
   end

--- a/app/controllers/decidim/assemblies/admin/assembly_followers_controller.rb
+++ b/app/controllers/decidim/assemblies/admin/assembly_followers_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    module Admin
+      # Controller that allows managing assembly followers.
+      #
+      class AssemblyFollowersController < Decidim::Assemblies::Admin::ApplicationController
+        include Concerns::AssemblyAdmin
+        layout "decidim/admin/assembly"
+
+        def index
+          @followers = Decidim::Assembly.find_by(
+            slug: permitted_params[:assembly_slug],
+            organization: current_organization
+          ).followers
+        end
+
+        private
+
+        def permitted_params
+          params.permit(:assembly_slug)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/follows_controller.rb
+++ b/app/controllers/decidim/follows_controller.rb
@@ -52,7 +52,8 @@ module Decidim
         event: "decidim.events.follows.created",
         event_class: Decidim::Admin::UserFollowEvent,
         resource: assembly,
-        affected_users: admin_users
+        affected_users: admin_users,
+        extra: { user: current_user }
       )
     end
 

--- a/app/controllers/decidim/follows_controller.rb
+++ b/app/controllers/decidim/follows_controller.rb
@@ -29,8 +29,8 @@ module Decidim
 
       CreateFollow.call(@form, current_user) do
         on(:ok) do
-          render :update_button
           send_notification
+          render :update_button
         end
 
         on(:invalid) do

--- a/app/controllers/decidim/follows_controller.rb
+++ b/app/controllers/decidim/follows_controller.rb
@@ -46,12 +46,24 @@ module Decidim
     end
 
     def send_notification
+      return if params[:slug].nil? || assembly.nil?
+
       Decidim::EventsManager.publish(
         event: "decidim.events.follows.created",
         event_class: Decidim::Admin::UserFollowEvent,
-        resource: Decidim::Assembly.find_by(slug: params[:slug], organization: current_organization),
-        affected_users: Decidim::User.where(admin: true, organization: current_organization)
+        resource: assembly,
+        affected_users: admin_users
       )
+    end
+
+    private
+
+    def assembly
+      Decidim::Assembly.find_by(slug: params[:slug], organization: current_organization)
+    end
+
+    def admin_users
+      Decidim::User.where(admin: true, organization: current_organization)
     end
   end
 end

--- a/app/controllers/decidim/follows_controller.rb
+++ b/app/controllers/decidim/follows_controller.rb
@@ -60,7 +60,7 @@ module Decidim
     private
 
     def assembly
-      Decidim::Assembly.find_by(slug: params[:slug], organization: current_organization)
+      @assembly ||= Decidim::Assembly.find_by(slug: params[:slug], organization: current_organization)
     end
 
     def admin_users

--- a/app/controllers/decidim/follows_controller.rb
+++ b/app/controllers/decidim/follows_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Decidim
+  class FollowsController < Decidim::ApplicationController
+    include FormFactory
+    before_action :authenticate_user!
+    helper_method :resource
+
+    def destroy
+      @form = form(Decidim::FollowForm).from_params(params)
+      @inline = params[:follow][:inline] == "true"
+      enforce_permission_to :delete, :follow, follow: @form.follow
+
+      DeleteFollow.call(@form, current_user) do
+        on(:ok) do
+          render :update_button
+        end
+
+        on(:invalid) do
+          render json: { error: I18n.t("follows.destroy.error", scope: "decidim") }, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def create
+      @form = form(Decidim::FollowForm).from_params(params)
+      @inline = params[:follow][:inline] == "true"
+      enforce_permission_to :create, :follow
+
+      CreateFollow.call(@form, current_user) do
+        on(:ok) do
+          render :update_button
+        end
+
+        on(:invalid) do
+          render json: { error: I18n.t("follows.create.error", scope: "decidim") }, status: :unprocessable_entity
+        end
+      end
+      send_notification
+    end
+
+    def resource
+      @resource ||= GlobalID::Locator.locate_signed(
+        params[:follow][:followable_gid]
+      )
+    end
+
+    def send_notification
+      Decidim::EventsManager.publish(
+        event: "decidim.events.follows.post.created",
+        event_class: Decidim::Admin::UserFollowEvent,
+        resource: @post,
+        followers: @post.participatory_space.followers
+        )
+    end
+  end
+end

--- a/app/controllers/decidim/follows_controller.rb
+++ b/app/controllers/decidim/follows_controller.rb
@@ -50,8 +50,7 @@ module Decidim
         event: "decidim.events.follows.created",
         event_class: Decidim::Admin::UserFollowEvent,
         resource: Decidim::Assembly.find_by(slug: params[:slug], organization: current_organization),
-        affected_users: Decidim::User.where(admin: true, organization: current_organization),
-        followers: Decidim::User.where(admin: true, organization: current_organization)
+        affected_users: Decidim::User.where(admin: true, organization: current_organization)
       )
     end
   end

--- a/app/events/decidim/admin/user_follow_event.rb
+++ b/app/events/decidim/admin/user_follow_event.rb
@@ -3,7 +3,6 @@
 module Decidim
   module Admin
   	class UserFollowEvent < Decidim::Events::SimpleEvent
-  		extend 
   		def resource_text
   			translated_attribute(resource.body)
   		end

--- a/app/events/decidim/admin/user_follow_event.rb
+++ b/app/events/decidim/admin/user_follow_event.rb
@@ -2,10 +2,10 @@
 
 module Decidim
   module Admin
-  	class UserFollowEvent < Decidim::Events::SimpleEvent
-  		def resource_text
-  			translated_attribute(resource.body)
-  		end
-  	end
+    class UserFollowEvent < Decidim::Events::SimpleEvent
+      def resource_text
+        translated_attribute(resource.body)
+      end
+    end
   end
 end

--- a/app/events/decidim/admin/user_follow_event.rb
+++ b/app/events/decidim/admin/user_follow_event.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+  	class UserFollowEvent < Decidim::Events::SimpleEvent
+  		extend 
+  		def resource_text
+  			translated_attribute(resource.body)
+  		end
+  	end
+  end
+end

--- a/app/events/decidim/admin/user_follow_event.rb
+++ b/app/events/decidim/admin/user_follow_event.rb
@@ -3,8 +3,14 @@
 module Decidim
   module Admin
     class UserFollowEvent < Decidim::Events::SimpleEvent
+      i18n_attributes :resource_user_name
+
       def resource_text
         translated_attribute(resource.body)
+      end
+
+      def resource_user_name
+        extra[:user].try(:[], :name)
       end
     end
   end

--- a/app/views/decidim/assemblies/admin/assembly_followers/index.html.erb
+++ b/app/views/decidim/assemblies/admin/assembly_followers/index.html.erb
@@ -1,0 +1,45 @@
+<div class='card' id="assembly_admins">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t("models.assembly.followers") %>
+    </h2>
+  </div>
+
+  <div class="card-section">
+    <div class="table-scroll">
+      <table class="stack">
+        <thead>
+          <tr>
+            <th><%= t("models.assembly_user_role.fields.name", scope: "decidim.admin") %></th>
+            <th><%= t("models.assembly_user_role.fields.email", scope: "decidim.admin") %></th>
+            <th><%= t("models.user.fields.invitation_sent_at", scope: "decidim.admin") %></th>
+            <th><%= t("models.user.fields.invitation_accepted_at", scope: "decidim.admin") %></th>
+            <th class="actions"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @followers.each do |follower| %>
+            <tr>
+              <td>
+                <%= follower.name %><br>
+              </td>
+              <td>
+                <%= follower.email %><br>
+              </td>
+              <td>
+                <% if follower.invitation_sent_at %>
+                  <%= l follower.invitation_sent_at, format: :short %>
+                <% end %>
+              </td>
+              <td>
+                <% if follower.invitation_accepted_at %>
+                  <%= l follower.invitation_accepted_at, format: :short %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/assemblies/admin/assembly_followers/index.html.erb
+++ b/app/views/decidim/assemblies/admin/assembly_followers/index.html.erb
@@ -1,4 +1,4 @@
-<div class='card' id="assembly_admins">
+<div class="card" id="assembly_admins">
   <div class="card-divider">
     <h2 class="card-title">
       <%= t("models.assembly.followers") %>

--- a/app/views/layouts/decidim/admin/assembly.html.erb
+++ b/app/views/layouts/decidim/admin/assembly.html.erb
@@ -68,7 +68,7 @@
           <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.moderations_path(current_participatory_space) %>
         </li>
       <% end %>
-      <li  <% if is_active_link?(Rails.application.routes.url_helpers.assembly_followers_path(current_participatory_space)) %> class = "is-active" <% end %>>
+      <li <% if is_active_link?(Rails.application.routes.url_helpers.assembly_followers_path(current_participatory_space)) %> class="is-active" <% end %>>
         <%= link_to "Followers", Rails.application.routes.url_helpers.assembly_followers_path(current_participatory_space) %>
       </li>
     </ul>

--- a/app/views/layouts/decidim/admin/assembly.html.erb
+++ b/app/views/layouts/decidim/admin/assembly.html.erb
@@ -1,0 +1,88 @@
+<% content_for :secondary_nav do %>
+  <div class="secondary-nav secondary-nav--subnav">
+    <ul>
+      <%= public_page_link decidim_assemblies.assembly_path(current_participatory_space) %>
+      <% if allowed_to? :update, :assembly, assembly: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.edit_assembly_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.edit_assembly_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :component, assembly: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.components_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("components", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.components_path(current_participatory_space) %>
+          <ul id="components-list">
+            <% current_participatory_space.components.each do |component| %>
+              <% if component.manifest.admin_engine && user_role_config.component_is_accessible?(component.manifest_name) %>
+                <li <% if is_active_link?(manage_component_path(component)) || is_active_link?(decidim_admin_assemblies.edit_component_path(current_participatory_space, component)) || is_active_link?(decidim_admin_assemblies.edit_component_permissions_path(current_participatory_space, component)) %> class="is-active" <% end %>>
+                  <%= link_to manage_component_path(component) do %>
+                    <%= translated_attribute component.name %>
+                    <% if component.primary_stat.present? %>
+                      <span class="component-counter <%= "component-counter--off" if component.primary_stat.zero? %>"><%= component.primary_stat %></span>
+                    <% end %>
+                  <% end %>
+                </li>
+              <% end %>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :category, assembly: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.categories_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.categories_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to?(:read, :attachment_collection, assembly: current_participatory_space) || allowed_to?(:read, :attachment, assembly: current_participatory_space) %>
+        <li>
+          <span class="secondary-nav__subtitle"><%= t("attachments", scope: "decidim.admin.menu.assemblies_submenu") %></span>
+          <ul>
+            <% if allowed_to? :read, :attachment_collection, assembly: current_participatory_space %>
+              <li <% if is_active_link?(decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space)) %> class="is-active" <% end %>>
+                <%= aria_selected_link_to t("attachment_collections", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space) %>
+              </li>
+            <% end %>
+            <% if allowed_to? :read, :attachment, assembly: current_participatory_space %>
+              <li <% if is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)) %> class="is-active" <% end %>>
+                <%= aria_selected_link_to t("attachment_files", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_attachments_path(current_participatory_space) %>
+              </li>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :assembly_member, assembly: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.assembly_members_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("assembly_members", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_members_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :assembly_user_role, assembly: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("assembly_admins", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :space_private_user, assembly: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.participatory_space_private_users_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("private_users", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.participatory_space_private_users_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <% if allowed_to? :read, :moderation, assembly: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.moderations_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.moderations_path(current_participatory_space) %>
+        </li>
+      <% end %>
+      <li  <% if is_active_link?(Rails.application.routes.url_helpers.assembly_followers_path(current_participatory_space)) %> class = "is-active" <% end %>>
+        <%= link_to "Followers", Rails.application.routes.url_helpers.assembly_followers_path(current_participatory_space) %>
+      </li>
+    </ul>
+  </div>
+<% end %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to translated_attribute(current_participatory_space.title), decidim_assemblies.assembly_path(current_participatory_space), target: "_blank" %>
+    </div>
+  </div>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
+<% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3,7 +3,7 @@ ca:
     events:
       follows:
         created:
-          notification_title: L'usuaria está seguint a <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: La usuaria "%{resource_user_name}" está seguint a <a href="%{resource_path}">%{resource_title}</a>.
     proposals:
       models:
         proposal:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,5 +1,9 @@
 ca:
   decidim:
+    events:
+      follows:
+        created:
+          notification_title: L'usuaria está seguint a <a href="%{resource_path}">%{resource_title}</a>.
     proposals:
       models:
         proposal:
@@ -11,3 +15,6 @@ ca:
       proposals:
         endorsements_card_row:
           comments: Comentaris
+  models:
+    assembly:
+      followers: Seguidors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,9 @@
+en:
+  decidim:
+    events:
+      follows:
+        created:
+          notification_title: The user is now following <a href="%{resource_path}">%{resource_title}</a>.
+  models:
+    assembly:
+      followers: Followers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
     events:
       follows:
         created:
-          notification_title: The user is now following <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: The user "%{resource_user_name}" is now following <a href="%{resource_path}">%{resource_title}</a>.
   models:
     assembly:
       followers: Followers

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,9 @@
 ca:
   decidim:
+    events:
+      follows:
+        created:
+          notification_title: La usuaria está siguiendo a <a href="%{resource_path}">%{resource_title}</a>.
     proposals:
       models:
         proposal:
@@ -11,3 +15,6 @@ ca:
       proposals:
         endorsements_card_row:
           comments: Comentarios
+  models:
+    assembly:
+      followers: Seguidores

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,7 +3,7 @@ ca:
     events:
       follows:
         created:
-          notification_title: La usuaria está siguiendo a <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: La usuaria "%{resource_user_name}"" está siguiendo a <a href="%{resource_path}">%{resource_title}</a>.
     proposals:
       models:
         proposal:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,7 +3,7 @@ ca:
     events:
       follows:
         created:
-          notification_title: La usuaria "%{resource_user_name}"" está siguiendo a <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: La usuaria "%{resource_user_name}" está siguiendo a <a href="%{resource_path}">%{resource_title}</a>.
     proposals:
       models:
         proposal:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,7 @@ Rails.application.routes.draw do
   mount Decidim::Core::Engine => '/'
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  #scope path: "/admin" do
+    get 'assemblies/:assembly_slug/followers', to: 'decidim/assemblies/admin/assembly_followers#index', as: 'assembly_followers'
+  #end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,5 @@ Rails.application.routes.draw do
   mount Decidim::Core::Engine => '/'
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  #scope path: "/admin" do
-    get 'assemblies/:assembly_slug/followers', to: 'decidim/assemblies/admin/assembly_followers#index', as: 'assembly_followers'
-  #end
+  get 'assemblies/:assembly_slug/followers', to: 'decidim/assemblies/admin/assembly_followers#index', as: 'assembly_followers'
 end

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -1,0 +1,12 @@
+# Overrides
+
+This document lists all the overrides that have been done at the Decidim platform. Those overrides can conflict with platform updates. During a platform upgrade they need to be compared to the ones of the Decidim project.
+
+The best way to spot these problems is by reviewing the changes in the files that are overridden using git history and apply the changes manually.
+
+## Modified
+
+- Add notification when a user follows an Assembly and followers list for each Assembly. (https://github.com/CodiTramuntana/decidim-i2cat-app/pull/22)
+	- `app/cells/decidim/follow_button/show.erb`
+	- `app/controllers/decidim/follows_controller.rb`
+	- `app/views/layouts/decidim/admin/assembly.html.erb`


### PR DESCRIPTION
Notifications are now being sent to all organization admins after a user follows an Assembly or one of its contents. All assemblies now include a followers view in order to see which users are following each assembly.

### Screenshots
**Assembly followers index**
![image](https://user-images.githubusercontent.com/56717126/81156679-7df7c180-8f86-11ea-92b8-bc45ac97af74.png)
