### PR TITLE
Upgrade decidim-challenges to v0.0.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'openssl'
 gem 'decidim', DECIDIM_VERSION
 gem 'decidim-term_customizer', git: 'https://github.com/CodiTramuntana/decidim-module-term_customizer'
 gem 'decidim-conferences', DECIDIM_VERSION
-gem 'decidim-challenges', '~> 0.0.10', git: 'https://github.com/gencat/decidim-module-challenges.git', branch: "layout/hide_titles_when_content_is_empty"
+gem 'decidim-challenges', '~> 0.0.10', git: 'https://github.com/gencat/decidim-module-challenges.git'
 
 group :development, :test do
   gem 'better_errors'

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'openssl'
 gem 'decidim', DECIDIM_VERSION
 gem 'decidim-term_customizer', git: 'https://github.com/CodiTramuntana/decidim-module-term_customizer'
 gem 'decidim-conferences', DECIDIM_VERSION
-gem 'decidim-challenges', '~> 0.0.9', git: 'https://github.com/gencat/decidim-module-challenges.git'
+gem 'decidim-challenges', '~> 0.0.10', git: 'https://github.com/gencat/decidim-module-challenges.git', branch: "layout/hide_titles_when_content_is_empty"
 
 group :development, :test do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,10 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-module-challenges.git
-  revision: 6ae030536a9755159af03a1596489b177129041a
+  revision: 65146ac9ad5a7d01545e73ec0fce826cf1bc8447
+  branch: layout/hide_titles_when_content_is_empty
   specs:
-    decidim-challenges (0.0.9)
+    decidim-challenges (0.0.10)
       decidim-core (~> 0.24.2)
 
 GEM
@@ -883,7 +884,7 @@ DEPENDENCIES
   byebug
   daemons
   decidim!
-  decidim-challenges (~> 0.0.9)!
+  decidim-challenges (~> 0.0.10)!
   decidim-conferences!
   decidim-dev!
   decidim-term_customizer!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,8 +221,7 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-module-challenges.git
-  revision: 65146ac9ad5a7d01545e73ec0fce826cf1bc8447
-  branch: layout/hide_titles_when_content_is_empty
+  revision: 2e69236d23b0ef357e41117d4b8b187186cea89d
   specs:
     decidim-challenges (0.0.10)
       decidim-core (~> 0.24.2)


### PR DESCRIPTION
To get the latest changes in show Challenge view that hide titles when there is no content.


### Before
![imatge](https://user-images.githubusercontent.com/199462/147664618-120911e1-9a10-42b9-b987-48590e848276.png)


### After
![imatge](https://user-images.githubusercontent.com/199462/147664723-4c911561-299b-41b5-9f6d-9952f94d2325.png)
