### PR TITLE
Fix some details to deploy 0.25

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.12.0)
+    bootsnap (1.16.0)
       msgpack (~> 1.2)
     browser (2.7.1)
     builder (3.2.4)
@@ -528,7 +528,7 @@ GEM
       tomlrb
     mixlib-shellout (3.2.7)
       chef-utils
-    msgpack (1.5.2)
+    msgpack (1.6.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     mustache (1.1.1)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,14 +3,3 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap"
-
-Bootsnap.setup(
-  cache_dir: File.expand_path(File.join("..", "tmp", "cache"), __dir__),
-  development_mode: ENV["RAILS_ENV"] || "development",
-  load_path_cache: true,
-  autoload_paths_cache: true,
-  disable_trace: false,
-  compile_cache_iseq: !ENV["SIMPLECOV"],
-  compile_cache_yaml: true
-)


### PR DESCRIPTION
- Update bootsnap and remove configurations in `boot.rb`
Because in deployment gives an error about that: https://github.com/Shopify/bootsnap/issues/73 and in anothers Decidim applications, this bootsnap configs not exists.

- Add entrypoint