### PR TITLE
Fix extra items in custom process nav

### DIFF
--- a/app/views/decidim/shared/_custom_process_nav.html.erb
+++ b/app/views/decidim/shared/_custom_process_nav.html.erb
@@ -16,13 +16,6 @@
             <% end %>
           </li>
         <% end %>
-        <% extra_items.each do |item| %>
-          <li class="<%= "is-active" if item[:active] %>">
-            <%= link_to item[:url], class: "process-nav__link #{item[:active] ? 'active' : nil}" do %>
-              <%= item[:name] %>
-            <% end %>
-          </li>
-        <% end %>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Do not render `extra_items` because all items are already in `items` in custom process nav.

Fixes: https://github.com/CodiTramuntana/decidim-i2cat-app/pull/111