### PR TITLE
Hide smart catalonia logo and feder footer for reptes.dca.cat

### DIFF
--- a/app/overrides/layouts/decidim/_application.rb
+++ b/app/overrides/layouts/decidim/_application.rb
@@ -3,5 +3,5 @@
 Deface::Override.new(virtual_path: +"layouts/decidim/_application",
                      name: "set organization host in data attributes",
                      add_to_attributes: "body",
-                     attributes: { "data-host": "<%= current_organization.host %>" },
+                     attributes: { "data-organization-id": "<%= current_organization.id %>" },
                      original: "41930cfb2025a54579e900288234b4b6e3e8aa04")

--- a/app/overrides/layouts/decidim/_application.rb
+++ b/app/overrides/layouts/decidim/_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Deface::Override.new(virtual_path: +"layouts/decidim/_application",
+                     name: "set organization host in data attributes",
+                     add_to_attributes: "body",
+                     attributes: { "data-host": "<%= current_organization.host %>" },
+                     original: "41930cfb2025a54579e900288234b4b6e3e8aa04")

--- a/app/overrides/layouts/decidim/_main_footer.rb
+++ b/app/overrides/layouts/decidim/_main_footer.rb
@@ -17,7 +17,7 @@ i2cat_text = <<~I2CAT
             <%= image_pack_tag "media/images/logo_I2CAT.jpg" %>
           </a>
         </div>
-        <div class="medium-2 small-12">
+        <div class="medium-2 small-12 smart-catalonia-logo">
           <a rel="license" class="cc-badge part-logo-footer-gencat"
             href="http://smartcatalonia.gencat.cat/ca/inici/" target="_blank">
             <%= image_pack_tag "media/images/logo_SmartCatalonia.jpg" %>
@@ -35,7 +35,7 @@ Deface::Override.new(virtual_path: +"layouts/decidim/_main_footer",
                      original: "25277dbf8f6306c2d1703a6fe82abf2be777fc7a")
 
 feder_text = <<~EOFEDER
-  <section class="footer__subhero extended subhero home-section">
+  <section class="footer__subhero extended subhero home-section footer-feder">
     <div class="row">
       <div class="columns small-12 large-9">
         <div class="row">

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -65,7 +65,8 @@
   }
 }
 
-body[data-host="reptes.dca.cat"] {
+// This is only for reptes.dca.cat
+body[data-organization-id="1"] {
   .smart-catalonia-logo {
     display: none;
   }

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -64,3 +64,18 @@
     align-items: flex-start;
   }
 }
+
+body[data-host="reptes.dca.cat"] {
+  .smart-catalonia-logo {
+    display: none;
+  }
+
+  .logos {
+    justify-content: center !important;
+    gap: 300px;
+  }
+
+  .footer-feder {
+    display: none;
+  }
+}


### PR DESCRIPTION
![image](https://github.com/CodiTramuntana/decidim-i2cat-app/assets/75725233/6493f37f-65fa-4c40-80d2-5f4d82ffaee2)