### PR TITLE
Hide custom footers for ARCA

### DIFF
--- a/app/overrides/layouts/decidim/_main_footer.rb
+++ b/app/overrides/layouts/decidim/_main_footer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 i2cat_text = <<~I2CAT
-  <section style="background: #fff;">
+  <section class="custom-footer" style="background: #fff;">
     <div class="row"><br/></div>
     <div class="row"">
       <div class="logos" style="display: flex;justify-content:space-between;align-items:center;">

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -80,3 +80,11 @@ body[data-organization-id="1"] {
     display: none;
   }
 }
+
+// This is only for agendaruralcat.cat
+body[data-organization-id="5"] {
+  .footer-feder,
+  .custom-footer {
+    display: none;
+  }
+}


### PR DESCRIPTION
Hide customs footer for ARCA instance.

![Screenshot from 2024-07-15 15-43-53](https://github.com/user-attachments/assets/b98ef161-3b56-4a71-9260-3db0115c9097)
