### PR TITLE
Use relative paths instead of absolute for ARCA customized menu

### DIFF
--- a/app/decorators/cells/decidim/assemblies/assembly_m_cell_decorator.rb
+++ b/app/decorators/cells/decidim/assemblies/assembly_m_cell_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Decidim::Assemblies::AssemblyMCellDecorator
+module ::Cells::Decidim::Assemblies::AssemblyMCellDecorator
 end
 
 ::Decidim::Assemblies::AssemblyMCell.class_eval do

--- a/app/decorators/controllers/decidim/pages_controller_decorator.rb
+++ b/app/decorators/controllers/decidim/pages_controller_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Decidim::PagesControllerDecorator
+module ::Controllers::Decidim::PagesControllerDecorator
 end
 
 ::Decidim::PagesController.class_eval do

--- a/app/decorators/decidim/follows_controller_decorator.rb
+++ b/app/decorators/decidim/follows_controller_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Decidim::FollowsControllerDecorator
+module ::Decidim::FollowsControllerDecorator
 end
 
 ::Decidim::FollowsController.class_eval do

--- a/config/initializers/arca_menu.rb
+++ b/config/initializers/arca_menu.rb
@@ -7,11 +7,11 @@ Decidim.menu :menu do |menu|
     menu.remove_item :conferences
     menu.add_item :agenda_rural,
                   I18n.t("arca_menu.agenda_rural"),
-                  "https://www.donadelasegarraalurgellunclavell.cat/assemblies/reptes",
+                  "/assemblies/reptes",
                   position: 2.01
-    menu.add_item :mon_rural,
-                  I18n.t("arca_menu.atlas_mon_rural"),
-                  "https://www.donadelasegarraalurgellunclavell.cat/assemblies/atles",
+    menu.add_item :atles_mon_rural,
+                  I18n.t("arca_menu.atles_mon_rural"),
+                  "/assemblies/atles",
                   position: 2.02
   end
 end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,7 +1,7 @@
 ca:
   arca_menu:
     agenda_rural: Agenda Rural de Catalunya
-    atlas_mon_rural: Atles del Món Rural
+    atles_mon_rural: Atles del Món Rural
   decidim:
     assemblies:
       assembly_m:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   arca_menu:
     agenda_rural: Catalonia's Rural Agenda
-    atlas_mon_rural: Rural World Atlas
+    atles_mon_rural: Rural World Atlas
   decidim:
     assemblies:
       assembly_m:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,7 +1,7 @@
 es:
   arca_menu:
     agenda_rural: Agenda Rural de Cataluña
-    atlas_mon_rural: Atlas del Mundo Rural
+    atles_mon_rural: Atlas del Mundo Rural
   decidim:
     assemblies:
       assembly_m:


### PR DESCRIPTION
The use of absolute paths causes Decidim to detect absolute paths as external URLs and shows a popup asking to open them. This was not happening in development.