### PR TITLE
Always show participatory processes menu option

### DIFF
--- a/config/initializers/arca_menu.rb
+++ b/config/initializers/arca_menu.rb
@@ -2,7 +2,6 @@
 
 Decidim.menu :menu do |menu|
   if current_organization.id.to_s == ENV.fetch("ARCA_ORGANIZATION_ID", nil)
-    menu.remove_item :participatory_processes
     menu.remove_item :assemblies
     menu.remove_item :conferences
     menu.add_item :agenda_rural,


### PR DESCRIPTION
Participatory processes should not be hidden when organization is ARCA.